### PR TITLE
Deploy with ZEIT Now

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 node_modules/
-dist/
+public/
 .parcel-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 yarn-error.log
-dist
+public/

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint . --fix",
     "dev": "parcel ./src/index.html --port 3000 --no-cache --open",
-    "prebuild": "rm -rf ./dist/",
-    "build": "parcel build ./src/index.html --no-content-hash --no-cache --public-url ./"
+    "prebuild": "rm -rf ./public/",
+    "build": "parcel build ./src/index.html --no-content-hash --no-cache --public-url ./ --out-dir public"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Just a suggestion, feel free to close if you have a strong hosting preference. Deploying with ZEIT Now will be completely free, since Manifest is static. Comes with all the goodness like automatic SSL and built-in CDN. No configuration required, just need to output a `public` directory.

The best part is **Preview Deployments**, though. When someone opens a PR, it will automatically deploy Manifest to a unique URL for that PR that stays up to date with changes, so you can review it live.

Here's an example of what it will look like: https://github.com/pacocoursey/manifest/pull/1 (you can see my changes live at https://manifest-git-pacocoursey-patch-2.pacocoursey.now.sh/)

You can even set it up so that every time the `develop` branch is updated, it will automatically deploy to https://staging.manifest.app

<img width="800" alt="Screen Shot 2020-01-19 at 12 15 41 PM" src="https://user-images.githubusercontent.com/34928425/72685996-7c78bb00-3ab5-11ea-922d-5a9dd145539f.png">
