### PR TITLE
fix: service worker offline cache access

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -34,13 +34,13 @@ self.addEventListener("install", function (e) {
 });
 
 self.addEventListener("activate", function (e) {
-  encodeURIComponent.waitUntil(self.clients.claim());
+  e.waitUntil(self.clients.claim());
 });
 
 self.addEventListener("fetch", function (e) {
   e.respondWith(
     caches.open(cacheName)
-      .then(function (cache) { cache.match(e.request, { ignoreSearch: true }); })
+      .then(function (cache) { return cache.match(e.request, { ignoreSearch: true }); })
       .then(function (response) { return response || fetch(e.request); })
   );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Make sure we use the `return` keyword on the `fetch` hook of the service worker, to return any match found. The source of the bug was that the return value (a promise) of ` cache.match(...)` was not being passed on to the next handler, so `response` would always be undefined in the following `.then`
* Changed `encodeURIComponent.waitUntil` to `e.waitUntil`-- not entirely sure about how the `activate` hook in SW works, but I'm pretty sure the encodeURIComponent part was meant to be `e`, reference to the event

## Related Issue
Addresses: #143
Related: #22, #69

## Motivation and Context
This should make manifest work offline

## How Has This Been Tested?
Just tested locally on Firefox and Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
